### PR TITLE
Created EmptyOrNil extension

### DIFF
--- a/EmptyOrNil.swift
+++ b/EmptyOrNil.swift
@@ -1,7 +1,7 @@
-extension Optional where Wrapped == String  {
+extension Optional where Wrapped: Collection  {
 
     /*
-    NOTE: Since this extends Optional rather than the possible String,
+    NOTE: Since this extends Optional rather than the possible collection,
     you don't use the "?" when calling it `isEmptyOrNil()`
     Example:
       var myString: String? = ""
@@ -13,8 +13,8 @@ extension Optional where Wrapped == String  {
     
     var isEmptyOrNil: Bool {
         switch self {
-        case .some(let string):
-            return string == ""
+        case .some(let collection):
+            return collection.isEmpty
         case .none:
             return true
         }
@@ -29,7 +29,7 @@ extension Optional where Wrapped == String  {
       nonNilString: String = myString.nilIfEmpty() ?? "NEATO"     // nonNilString will equal "NEATO"
     */
     
-    func nilIfEmpty() -> String? {
+    func nilIfEmpty() -> Wrapped? {
         return isEmptyOrNil ? nil : self!
     }
 }

--- a/String+Helpers.swift
+++ b/String+Helpers.swift
@@ -1,0 +1,35 @@
+extension Optional where Wrapped == String  {
+
+    /*
+    NOTE: Since this extends Optional rather than the possible String,
+    you don't use the "?" when calling it `isEmptyOrNil()`
+    Example:
+      var myString: String? = ""
+      myString.isEmptyOrNil  // Evaluates to true.
+      myString = nil
+      myString.isEmptyOrNil  // Also evaluates to true.
+      myString?.isEmptyOrNil // Will not compile.
+    */
+    
+    var isEmptyOrNil: Bool {
+        switch self {
+        case .some(let string):
+            return string == ""
+        case .none:
+            return true
+        }
+    }
+    
+    /*
+    This allows you to use nil coalescing to on a string, whether it's nil or just empty. 
+    Example:
+      var myString: String? = ""
+      var nonNilString: String = myString.nilIfEmpty() ?? "WOOT"  // nonNilString will equal "WOOT"
+      myString = nil
+      nonNilString: String = myString.nilIfEmpty() ?? "NEATO"     // nonNilString will equal "NEATO"
+    */
+    
+    func nilIfEmpty() -> String? {
+        return isEmptyOrNil ? nil : self!
+    }
+}


### PR DESCRIPTION
- Contains an extension on `Optional<Collection>` which provides helpers for dealing with states where you would want to treat nil and empty Collections the same.
- `var isEmptyOrNil: Bool` is a computed property which returns true if the optional is nil or if it's non-nil and the collection is empty.
- `func nilIfEmpty() -> Wrapped?` is a function which only returns a string if the optional is both non-nil and contains a non-empty wrapped collection.